### PR TITLE
Second Instance in Production throws Exception

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,8 @@ class Deeplink extends EventEmitter {
     };
 
     private secondInstanceEvent = (event: Event, argv: string[]) => {
-        if (os.platform() === 'darwin') {
+        const {debugLogging } = this.config;
+        if (os.platform() === 'darwin' && debugLogging) {
             this.logger.error(
                 `electron-deeplink: the app event 'second-instance' fired, this should not of happened, please check your packager bundleId config`
             );


### PR DESCRIPTION
The logger does not exist in production, and it causes an alert to show when a second instance is opened because `logger.error` is undefined.

Adding an object check should fix the problem.

Happens when trying to start a dev version, when prod is already open.


![image](https://user-images.githubusercontent.com/5509813/133897746-d1f09873-b005-482a-935b-1a2e3bcb858e.png)
