### PR TITLE
Fix Mac received event not fired when App is already ready

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import { App, BrowserWindow } from 'electron';
+import { App, BrowserWindow, Event } from 'electron';
 import { EventEmitter } from 'events';
 import stub from './stub';
 import { infoPlistTemplate } from './templates';
@@ -81,7 +81,7 @@ class Deeplink extends EventEmitter {
         if (os.platform() === 'darwin') {
             app.setAsDefaultProtocolClient(protocol);
 
-            app.on('will-finish-launching', () => {
+            app.whenReady(() => {
                 app.on('open-url', (event, url) => this.darwinOpenEvent(event, url, 'open-url'));
                 app.on('open-file', (event, url) => this.darwinOpenEvent(event, url, 'open-file'));
             });


### PR DESCRIPTION
The use of `will-finish-launching` means apps that initialize deeplink when app is already ready will not work.
There could be multiple reasons for this, in my case we have to create the window no sooner than app ready, because we rely on header manipulation in session. Perhaps we can go around  this somehow, however I feel this library should handle this case.

Is there any reason this library uses `will-finish-launching` over `ready`? If not, I think `whenReady` is best for this.
I haven't tried, but perhaps it's possible to exclude this completely, since registering event listeners before app is ready should be totally okay?
